### PR TITLE
Make the extra margin on iPhone X devices optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can check the example for the advanced usage
 | onPressCancel       | function  |     function      | set your own function for the cancel button's onPress functionality                                   |
 | cancelComponent     | component |     component     | set your own component instead of cancel component                                                    |
 | cancelButtonDisable |  boolean  |       false       | disable cancel button component                                                                       |
-| autoFocus           |  boolean  |       true        | change the autoFocus mode for the TextInput                                                           |
+| autoFocus           |  boolean  |       true        | change the autoFocus mode for the TextInput                          | noExtraMargin           |  boolean  |       false        | remove extra padding on iPhone X devices                                                           |
 | onPressToFocus      |  boolean  |       false       | when enable it, onPress will automatically focus on the TextInput and opens the soft virtual keyboard |
 
 ## Expo Compatibility

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ You can check the example for the advanced usage
 | onPressCancel       | function  |     function      | set your own function for the cancel button's onPress functionality                                   |
 | cancelComponent     | component |     component     | set your own component instead of cancel component                                                    |
 | cancelButtonDisable |  boolean  |       false       | disable cancel button component                                                                       |
-| autoFocus           |  boolean  |       true        | change the autoFocus mode for the TextInput                          | noExtraMargin           |  boolean  |       false        | remove extra padding on iPhone X devices                                                           |
+| autoFocus           |  boolean  |       true        | change the autoFocus mode for the TextInput      |
+
+| noExtraMargin           |  boolean  |       false        | remove extra padding on iPhone X devices   |                                                        
 | onPressToFocus      |  boolean  |       false       | when enable it, onPress will automatically focus on the TextInput and opens the soft virtual keyboard |
 
 ## Expo Compatibility

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ You can check the example for the advanced usage
 | onPressCancel       | function  |     function      | set your own function for the cancel button's onPress functionality                                   |
 | cancelComponent     | component |     component     | set your own component instead of cancel component                                                    |
 | cancelButtonDisable |  boolean  |       false       | disable cancel button component                                                                       |
-| autoFocus           |  boolean  |       true        | change the autoFocus mode for the TextInput      |
-
-| noExtraMargin           |  boolean  |       false        | remove extra padding on iPhone X devices   |                                                        
+| autoFocus           |  boolean  |       true        | change the autoFocus mode for the TextInput                                                                       |
+| noExtraMargin           |  boolean  |       false        | remove extra padding on iPhone X devices                                                                       |
 | onPressToFocus      |  boolean  |       false       | when enable it, onPress will automatically focus on the TextInput and opens the soft virtual keyboard |
 
 ## Expo Compatibility

--- a/lib/src/SearchBar.js
+++ b/lib/src/SearchBar.js
@@ -38,7 +38,9 @@ export default class SearchBar extends Component {
       textInputDisable,
       textInputComponent,
       cancelIconComponent,
-      cancelButtonDisable
+      cancelButtonDisable,
+      noExtraMargin
+      
     } = this.props;
 
     return (
@@ -46,7 +48,7 @@ export default class SearchBar extends Component {
         style={[
           styles.center,
           container(this.props),
-          styles.ifIPhoneXHeader,
+          styles.ifIPhoneXHeader(noExtraMargin),
           _shadowStyle(shadowColor)
         ]}
         onPress={() => {

--- a/lib/src/SearchBar.js
+++ b/lib/src/SearchBar.js
@@ -4,7 +4,8 @@ import { View, TextInput, TouchableOpacity } from "react-native";
 import styles, {
   container,
   _shadowStyle,
-  textInputStyle
+  textInputStyle,
+  ifIPhoneXHeader
 } from "./SearchBar.style";
 import SearchIcon from "./components/SearchIcon";
 import SearchCancel from "./components/SearchCancel";
@@ -48,7 +49,7 @@ export default class SearchBar extends Component {
         style={[
           styles.center,
           container(this.props),
-          styles.ifIPhoneXHeader(noExtraMargin),
+          ifIPhoneXHeader(noExtraMargin),
           _shadowStyle(shadowColor)
         ]}
         onPress={() => {

--- a/lib/src/SearchBar.style.js
+++ b/lib/src/SearchBar.style.js
@@ -49,6 +49,25 @@ export function _shadowStyle(shadowColor) {
   };
 }
 
+export function ifIPhoneXHeader(noExtraMargin) {
+  if (noExtraMargin){
+    return {
+       marginTop: 16
+    };
+  } else {
+    return {
+      ...ifIphoneX(
+        {
+          marginTop: 44
+        },
+        {
+          marginTop: 16
+        }
+      )
+    };
+  }
+}
+
 export default {
   containerGlue: {
     flex: 1,
@@ -68,15 +87,5 @@ export default {
   center: {
     alignSelf: "center",
     alignContent: "center"
-  },
-  ifIPhoneXHeader: {
-    ...ifIphoneX(
-      {
-        marginTop: 44
-      },
-      {
-        marginTop: 16
-      }
-    )
   }
 };


### PR DESCRIPTION
With safeareaview this is not needed. 
https://facebook.github.io/react-native/docs/safeareaview.html
