### PR TITLE
fix: packaging hygiene — peers, types/exports map, files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dynamic-search-bar",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Fully customizable and dynamic Search Bar for React Native.",
   "keywords": [
     "gradient",
@@ -22,10 +22,25 @@
   "homepage": "https://www.freakycoder.com",
   "bugs": "https://github.com/WrathChaos/react-native-dynamic-search-bar/issues",
   "main": "./build/dist/SearchBar.js",
+  "types": "./build/dist/SearchBar.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/dist/SearchBar.d.ts",
+      "default": "./build/dist/SearchBar.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "build/dist",
+    "!build/dist/package.json",
+    "!build/dist/tsconfig.tsbuildinfo"
+  ],
   "repository": "git@github.com:WrathChaos/react-native-dynamic-search-bar.git",
   "author": "Kuray (FreakyCoder) <kurayogun@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-native": ">=0.64.0",
     "react-native-spinkit": ">= 1.5.0",
     "@freakycoder/react-native-bounceable": ">= 0.2.2"
   },


### PR DESCRIPTION
Found while doing the packaging-hygiene sweep across the fleet: react/react-native were missing from peerDependencies, there was no "types" field or exports map, and the tarball ships raw TS sources, dotfiles, tsconfig.json, .github/ and a tsbuildinfo alongside the build output. Added react/react-native peers, explicit types + exports map (types condition first, matching the published build/dist layout), and a "files" whitelist keeping build/dist including local-assets (the PNGs the component require()s at runtime). The react-native-spinkit and @freakycoder/react-native-bounceable peers are BOTH genuinely imported in SearchBar.tsx and stay. No source changes. Publish as 2.0.3 after the npm account migration.